### PR TITLE
extend finder methods to relations in Rails 4.2

### DIFF
--- a/app/models/concerns/acts_as_sluggable.rb
+++ b/app/models/concerns/acts_as_sluggable.rb
@@ -109,10 +109,8 @@ module ActsAsSluggable
   end
 
   module ClassMethods
-    unless ::ActiveRecord::VERSION::MAJOR == 4 && ::ActiveRecord::VERSION::MINOR == 2
-      def relation
-        super.tap { |relation| relation.extend(FinderMethods) }
-      end
+    def relation
+      super.tap { |relation| relation.extend(FinderMethods) }
     end
   end
 
@@ -135,7 +133,5 @@ module ActsAsSluggable
       args.first.is_a?(Array) || args.first.to_i > 0
     end
   end
-
-
 end
 


### PR DESCRIPTION
Currently, in effective_slugs, using Rails 4.2:

```
2.2.3 :005 > Effective::Page.method(:find)
 => #<Method: Class(ActsAsSluggable::FinderMethods)#find>
2.2.3 :006 > Effective::Page.where(draft: false).method(:find)
 => #<Method: Effective::Page::ActiveRecord_Relation(ActiveRecord::FinderMethods)#find>
```

The find method is still defined on the Relation class so it needs to be `tap`ped into still.
